### PR TITLE
fix: add fill forwards to prevent theme toggle flicker

### DIFF
--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -34,7 +34,7 @@ function toggleTheme(event: MouseEvent) {
     return
   }
 
-  // @ts-expect-error: Transition API
+  // @ts-expect-error experimental API
   const transition = document.startViewTransition(async () => {
     toggleDark()
   })
@@ -51,6 +51,7 @@ function toggleTheme(event: MouseEvent) {
       {
         duration: 400,
         easing: 'ease-in',
+        fill: 'forwards',
         pseudoElement: isDark.value
           ? '::view-transition-old(root)'
           : '::view-transition-new(root)',


### PR DESCRIPTION
## 问题描述
切换主题时会出现闪烁，因为动画结束后 clipPath 会回退到初始状态。

## 解决方案
添加 `fill: 'forwards'` 到动画配置中，使动画结束后保持最终状态，与 View Transition API 的切换过程对齐。

## 相关代码
- `src/components/ThemeToggle.vue` 第 54 行